### PR TITLE
Set architectures metadata property to wildcard

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=Allows to move each Braccio parts using simple calls.
 paragraph=Works only for TinkerKit Braccio.
 category=Device Control
 url=http://www.arduino.org/learning/reference/Braccio
-architectures=avr, samd, sam
+architectures=*


### PR DESCRIPTION
There is nothing in the library code that restricts it to AVR, SAM, SAMD architecture. The unnecessarily restrictive `architectures` value caused the library's examples to appear under **File > Examples > INCOMPATIBLE** and an architecture mismatch to be displayed during compilation when a board of any other architecture was selected.

Closes https://github.com/arduino-org/arduino-library-braccio/issues/5

CC: @Sebbenbear